### PR TITLE
Add macro `parinfer--switch-to'

### DIFF
--- a/parinfer-theme.el
+++ b/parinfer-theme.el
@@ -16,16 +16,13 @@
    "Parinfer dim paren face."
    :group 'parinfer-group)
 
-(defun parinfer--enable-dim-parens ()
-  "Indent Mode dim close parens."
-  (font-lock-add-keywords nil
-                          '((")\\|}\\|]" . 'parinfer-dim-paren-face)))
-  (font-lock-flush))
-
-(defun parinfer--disable-dim-parens ()
-  "Indent Mode not dim close parens."
-  (font-lock-remove-keywords nil
-                          '((")\\|}\\|]" . 'parinfer-dim-paren-face)))
+(defun parinfer--set-dim-parens (mode)
+  "Set dim close parens, which is depended MODE."
+  (cl-case mode
+    (paren (font-lock-add-keywords
+            nil '((")\\|}\\|]" . 'parinfer-dim-paren-face))))
+    (indent (font-lock-remove-keywords
+             nil '((")\\|}\\|]" . 'parinfer-dim-paren-face)))))
   (font-lock-flush))
 
 (provide 'parinfer-theme)


### PR DESCRIPTION
能简化的东西，到目前为止，我都尽我的能力简化了，另外一个问题就是： emacs 核心已经添加了一个类似dash的包，名字叫 map 还是 seq，我忘记了，如果可以，最好使用它，而不是 dash， 这样可以简化依赖。