### PR TITLE
simplify code

### DIFF
--- a/parinfer-ext.el
+++ b/parinfer-ext.el
@@ -3,7 +3,7 @@
 ;; Copyright (c) 2016, Shi Tianshu
 
 ;; Author: Shi Tianshu
-;; Homepage: https://github.com/DogLooksGood/parinfer-ext:mode
+;; Homepage: https://github.com/DogLooksGood/parinfer-mode
 ;; Keywords: Parinfer
 
 ;; This file is not part of GNU Emacs.
@@ -63,7 +63,7 @@ Use rainbow-delimiters for Paren Mode, and dim-style parens for Indent Mode."
   (when (bound-and-true-p rainbow-delimiters-mode)
     (rainbow-delimiters-mode-disable))
   (font-lock-add-keywords
-   nil '((")\\|}\\|]" . 'parinfer-dim-paren-face)))  
+   nil '((")\\|}\\|]" . 'parinfer-dim-paren-face)))
   (font-lock-flush))
 
 ;; -----------------------------------------------------------------------------
@@ -185,7 +185,7 @@ Use rainbow-delimiters for Paren Mode, and dim-style parens for Indent Mode."
     '(parinfer-lispy:parens
       parinfer-lispy:braces
       parinfer-lispy:brackets
-      parinfer-lispy:space))    
+      parinfer-lispy:space))
   (add-hook 'lispy-mode-hook #'parinfer-lispy:init)
 
   :unmount

--- a/parinfer.el
+++ b/parinfer.el
@@ -129,7 +129,7 @@ used to match command.
  --------------   -------------------------------------------
  default          Invoke parinfer (delay on large sexp)
  instantly        Invoke parinfer instantly
- disable          Do not invoke parinfer")
+ skip             Do not invoke parinfer")
 
 ;; -----------------------------------------------------------------------------
 ;; Internal variable and constants
@@ -277,7 +277,7 @@ CLAUSES are the codes for lifecycle.
   parinfer--mode)
 
 (defun parinfer-strategy-parse (strategy-name)
-  "Parse strategy, which is named STRATEGY-NAME in `parinfer-strategy'.)
+  "Parse strategy, which is named STRATEGY-NAME in `parinfer-strategy'.
 
 Its output is a plist, which context is *similar* the below:
 
@@ -335,7 +335,7 @@ COMMANDS can be:
     (message "Parinfer: Indent Mode")))
 
 (defun parinfer--switch-to-indent-mode ()
-  "Switch to Indent Mode, this will apply indent fix on whole buffer.)
+  "Switch to Indent Mode, this will apply indent fix on whole buffer.
 If this is the first switching for current buffer and indent mode will change
 Buffer text, we should see a confirm message."
   (if (not parinfer--first-load)
@@ -448,7 +448,7 @@ Buffer text, we should see a confirm message."
        (t "nothing")))))
 
 (defun parinfer--invoke-parinfer (&optional pos)
-  "Supposed to be called after each content change.)
+  "Supposed to be called after each content change.
 POS is the position we want to call parinfer."
   (if (and pos (not (eq pos (point))))
       (let ((current-pos (point)))

--- a/parinfer.el
+++ b/parinfer.el
@@ -716,7 +716,7 @@ if there's any change, display a confirm message in minibuffer."
           nil)
       (if (and changed-lines
                (not (string= text (plist-get result :text))))
-          (if (y-or-n-p "Caution! Buffer will be modified if you swith to Indent mode, continue? ")
+          (if (y-or-n-p "Caution: YES = Indent-mode (Buffer will be modified); NO = Paren-mode, which one? ")
               (progn (cl-loop for l in changed-lines do
                               (parinfer--goto-line (1+ (plist-get l :line-no)))
                               (delete-region (line-beginning-position)


### PR DESCRIPTION
主要的更改，是把 parinfer-define-extension 简化了一下，现在任何一个 keyword 都生成对应的函数了，而不是里面硬编码的四个 keyword，方便以后扩展 keywords