### PR TITLE
:check 功能

### DIFF
--- a/parinfer-ext.el
+++ b/parinfer-ext.el
@@ -52,11 +52,13 @@
   "Pretty parens.
 
 Use rainbow-delimiters for Paren Mode, and dim-style parens for Indent Mode."
+  :check
+  (parinfer-check "'rainbow-delimiters' package is not installed."
+    (fboundp 'rainbow-delimiters-mode))
   :paren
   (font-lock-remove-keywords
    nil '((")\\|}\\|]" . 'parinfer-dim-paren-face)))
-  (when (fboundp 'rainbow-delimiters-mode)
-    (rainbow-delimiters-mode-enable))
+  (rainbow-delimiters-mode-enable)
   (font-lock-flush)
 
   :indent
@@ -80,18 +82,20 @@ Use rainbow-delimiters for Paren Mode, and dim-style parens for Indent Mode."
 
 (parinfer-define-extension company
   "Compatibility fix for company-mode."
+  :check
+  (parinfer-check "'company' package is not installed."
+    (bound-and-true-p company-mode))
+
   :indent
-  (when (bound-and-true-p company-mode)
-    (add-hook 'company-completion-cancelled-hook
-              'parinfer-company:cancel t t)
-    (remove-hook 'company-completion-finished-hook
-                 'parinfer-company:finish t))
+  (add-hook 'company-completion-cancelled-hook
+            'parinfer-company:cancel t t)
+  (remove-hook 'company-completion-finished-hook
+               'parinfer-company:finish t)
   :paren
-  (when (bound-and-true-p company-mode)
-    (add-hook 'company-completion-finished-hook
-              'parinfer-company:finish t t)
-    (remove-hook 'company-completion-cancelled-hook
-                 'parinfer-company:cancel t)))
+  (add-hook 'company-completion-finished-hook
+            'parinfer-company:finish t t)
+  (remove-hook 'company-completion-cancelled-hook
+               'parinfer-company:cancel t))
 
 ;; -----------------------------------------------------------------------------
 ;; lispy
@@ -173,6 +177,9 @@ Use rainbow-delimiters for Paren Mode, and dim-style parens for Indent Mode."
 
 (parinfer-define-extension lispy
   "Integration with Lispy."
+  :check
+  (parinfer-check "'lispy' package is not installed."
+    (fboundp 'lispy-mode))
 
   :indent
   (lispy-mode 1)

--- a/parinfer-ext.el
+++ b/parinfer-ext.el
@@ -244,5 +244,24 @@ Use rainbow-delimiters for Paren Mode, and dim-style parens for Indent Mode."
   :mount
   (define-key parinfer-mode-map [remap yank] 'parinfer-smart-yank:yank))
 
+;; -----------------------------------------------------------------------------
+;; adjust-parens (Make tab smart)
+;; -----------------------------------------------------------------------------
+
+(parinfer-define-extension adjust-parens
+  "Add adjust-parens feature"
+  :check
+  (parinfer-check "'adjust-parens' package is not installed."
+    (fboundp 'adjust-parens-mode))
+
+  :indent
+  (adjust-parens-mode 1)
+
+  :paren
+  (adjust-parens-mode -1)
+
+  :unmount
+  (adjust-parens-mode -1))
+
 (provide 'parinfer-ext)
 ;;; parinfer-ext.el ends here


### PR DESCRIPTION
:check 功能当前缺失的是，依赖提醒功能，主要的原因其实挺扯，就是显示太罗嗦，所以我让它 在 debug 开启后 显示。 adjust-par 这个扩展，我只加了一个基本框架。能用，但我不知道这两个包到底有没有冲突的可能性。