### PR TITLE
bugfix: paredit-join-sexp -> paredit-join-sexps

### DIFF
--- a/parinfer-ext.el
+++ b/parinfer-ext.el
@@ -130,7 +130,7 @@ Use rainbow-delimiters for Paren Mode, and dim-style parens for Indent Mode."
         (define-key parinfer-mode-map (kbd "C-(") 'paredit-backward-slurp-sexp)
         (define-key parinfer-mode-map (kbd "C-)") 'paredit-forward-slurp-sexp)
         (define-key parinfer-mode-map (kbd "M-r") 'paredit-raise-sexp)
-        (define-key parinfer-mode-map (kbd "M-j") 'paredit-join-sexp)
+        (define-key parinfer-mode-map (kbd "M-j") 'paredit-join-sexps)
         (define-key parinfer-mode-map (kbd "M-s") 'paredit-splice-sexp)
         (define-key parinfer-mode-map (kbd "M-S") 'paredit-split-sexp))
     (message "Parinfer extension paredit: It seems Paredit is not installed!")))


### PR DESCRIPTION
Small typo for the paredit extension. The function name is `paredit-join-sexps` not `paredit-join-sexp`.