### PR TITLE
remove dependency on package.el

### DIFF
--- a/parinfer-ext.el
+++ b/parinfer-ext.el
@@ -205,9 +205,8 @@ Use rainbow-delimiters for Paren Mode, and dim-style parens for Indent Mode."
     (call-interactively 'self-insert-command)))
 
 (defun parinfer-lispy:init ()
-  (if (package-installed-p 'lispy)
+  (if (fboundp 'lispy)
       (progn
-        (require 'lispy)
         (define-key parinfer-mode-map (kbd "(") 'parinfer-lispy:parens)
         (define-key parinfer-mode-map (kbd "{") 'parinfer-lispy:braces)
         (define-key parinfer-mode-map (kbd "[") 'parinfer-lispy:brackets)


### PR DESCRIPTION
I use `use-package` and `straight`, and the lispy extensions isn't working because it requires package.el, which I don't have