### PR TITLE
extension fboundp lispy -> lispy-mode

### DIFF
--- a/parinfer-ext.el
+++ b/parinfer-ext.el
@@ -205,7 +205,7 @@ Use rainbow-delimiters for Paren Mode, and dim-style parens for Indent Mode."
     (call-interactively 'self-insert-command)))
 
 (defun parinfer-lispy:init ()
-  (if (fboundp 'lispy)
+  (if (fboundp 'lispy-mode)
       (progn
         (define-key parinfer-mode-map (kbd "(") 'parinfer-lispy:parens)
         (define-key parinfer-mode-map (kbd "{") 'parinfer-lispy:braces)


### PR DESCRIPTION
seems fboundp can't find `lispy` symbol, use `lispy-mode` instead.