### PR TITLE
Add note about disabling tabs

### DIFF
--- a/README.org
+++ b/README.org
@@ -134,7 +134,7 @@ The extensions that will be enabled. The list could contain followings:
 #+END_SRC
 
 * Troubleshooting
-If Parinfer seems to be indenting incorrectly, ensure `indent-tabs-mode` is set to `nil`. While Parinfer's theoretical model is able to correctly handle indentation with tabs, `parinfer-mode` can currently only handle indentation using spaces.
+If Parinfer seems to be indenting incorrectly, ensure ~indent-tabs-mode~ is set to ~nil~ via ~(setq-default indent-tabs-mode nil)~. While Parinfer's theoretical model is able to correctly handle indentation with tabs, ~parinfer-mode~ can currently only handle indentation using spaces.
 
 * Credits
 - [[https://github.com/shaunlebron][shaunlebron]] :: Create [[https://shaunlebron.github.io/parinfer/][Parinfer]].

--- a/README.org
+++ b/README.org
@@ -133,6 +133,9 @@ The extensions that will be enabled. The list could contain followings:
   (setq parinfer-lighters '(" Parinfer:Indent" . "Parinfer:Paren"))
 #+END_SRC
 
+* Troubleshooting
+If Parinfer seems to be indenting incorrectly, ensure `indent-tabs-mode` is set to `nil`. While Parinfer's theoretical model is able to correctly handle indentation with tabs, `parinfer-mode` can currently only handle indentation using spaces.
+
 * Credits
 - [[https://github.com/shaunlebron][shaunlebron]] :: Create [[https://shaunlebron.github.io/parinfer/][Parinfer]].
 - [[https://github.com/oakmac][oakmac]] :: Bring Parinfer to Emacs with [[https://github.com/oakmac/parinfer-elisp][parinfer-elisp]].


### PR DESCRIPTION
Because `parinfer-mode` cannot handle tabs currently, this commit adds a note to the README that users should ensure that `indent-tabs-mode` is disabled.

I was very confused why `parinfer-mode` appeared to be incorrectly indenting, especially after newlines and `TAB` did not work as expected. After finding [this comment](https://github.com/DogLooksGood/parinfer-mode/issues/52#issuecomment-313760423) I disabled `indent-tabs-mode` and everything suddenly worked exactly as I expected.  I hope adding a note to the README can make troubleshooting easier for other users in the future.