### PR TITLE
Fix parinfer-save-excursion errors

### DIFF
--- a/parinfer.el
+++ b/parinfer.el
@@ -181,9 +181,10 @@ used to match command.
 ;; Alias
 ;; -----------------------------------------------------------------------------
 
-(if (fboundp 'save-mark-and-excursion)
-    (defalias 'parinfer-save-excursion 'save-mark-and-excursion)
-  (defalias 'parinfer-save-excursion 'save-excursion))
+(eval-when-compile
+  (if (fboundp 'save-mark-and-excursion)
+      (defalias 'parinfer-save-excursion 'save-mark-and-excursion)
+    (defalias 'parinfer-save-excursion 'save-excursion)))
 
 ;; -----------------------------------------------------------------------------
 ;; Macros


### PR DESCRIPTION
Macro aliases should be defined at compile time, otherwise errors can happen.

Per <https://debbugs.gnu.org/cgi/bugreport.cgi?bug=44102>; I thought this were an issue with native-comp, but it turns out isn't.